### PR TITLE
Corrected resource links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ Note that there are multiple patterns for event sourcing, the above being one of
 
 ### Resources
 
-* monstershopen java: https://github.com/andreasBerre/monstershopen
-* monstershopen c#: https://github.com/oven/monstershopen.net
+* The Monster Shop in Java: https://github.com/andreasBerre/monsterbutikken
+* The Monster Shop in C#: https://github.com/oven/monsterbutikken.net
 * slides from presentation: http://goo.gl/G1U9HS  


### PR DESCRIPTION
This commit fixes #7 by updating the links and their description.
